### PR TITLE
fix: fixed object-shorthand

### DIFF
--- a/.changeset/loud-trees-sparkle.md
+++ b/.changeset/loud-trees-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@kode-frontend/eslint-config": patch
+---
+
+fix: object-shorthand теперь `warn`, вместо `error`

--- a/packages/eslint-config/src/common-rules/es6.js
+++ b/packages/eslint-config/src/common-rules/es6.js
@@ -90,7 +90,7 @@ module.exports = {
     // require method and property shorthand syntax for object literals
     // https://eslint.org/docs/rules/object-shorthand
     'object-shorthand': [
-      'error',
+      'warn',
       'always',
       {
         ignoreConstructors: false,


### PR DESCRIPTION
Fixed object-shorthand from `error` to `warn`