### PR TITLE
fix(session-interceptor): Исправлен интерсептор сессии

### DIFF
--- a/packages/session-interceptor/src/session-interceptor.ts
+++ b/packages/session-interceptor/src/session-interceptor.ts
@@ -90,15 +90,20 @@ export const startSessionInterceptor = <T extends Tokens>({
         if (subscribers.getAllowToRefetch()) {
           subscribers.setAllowToRefetch(false)
 
-          const tokensResponse = await tokensGetter()
-
-          if (tokensResponse?.accessToken) {
-            if (onGotNewTokens) {
-              onGotNewTokens(tokensResponse)
+          try {
+            const tokensResponse = await tokensGetter()
+  
+            if (tokensResponse?.accessToken) {
+              if (onGotNewTokens) {
+                onGotNewTokens(tokensResponse)
+              }
             }
-          }
 
-          subscribers.setAllowToRefetch(true)
+            subscribers.setAllowToRefetch(true)
+          } catch {
+            subscribers.setAllowToRefetch(true)
+            return
+          }
         }
 
         return new Promise(resolve => {

--- a/packages/session-interceptor/src/session-interceptor.ts
+++ b/packages/session-interceptor/src/session-interceptor.ts
@@ -98,12 +98,11 @@ export const startSessionInterceptor = <T extends Tokens>({
                 onGotNewTokens(tokensResponse)
               }
             }
-
-            subscribers.setAllowToRefetch(true)
           } catch {
-            subscribers.setAllowToRefetch(true)
             return
-          }
+          } finally {
+            subscribers.setAllowToRefetch(true)
+          }   
         }
 
         return new Promise(resolve => {

--- a/packages/session-interceptor/src/session-interceptor.ts
+++ b/packages/session-interceptor/src/session-interceptor.ts
@@ -10,6 +10,7 @@ type SessionInterceptorArg<T> = {
   tokensGetter: () => Promise<T>
   onGotNewTokens?: (tokens: T) => void
   onInvalidRefreshResponse: () => void
+  onRefreshError?: () => void
   onUnhandledError?: (e: AxiosError) => void
   /** If specified then `invalidAccessTokenErrors` will be ignored */
   checkAccessTokenInvalid?: (response: AxiosResponse<any, any>) => boolean
@@ -24,6 +25,7 @@ export const startSessionInterceptor = <T extends Tokens>({
   tokensGetter,
   onGotNewTokens,
   onInvalidRefreshResponse,
+  onRefreshError,
   onUnhandledError,
   checkRefreshTokenInvalid,
   checkAccessTokenInvalid,
@@ -99,6 +101,7 @@ export const startSessionInterceptor = <T extends Tokens>({
               }
             }
           } catch {
+            onRefreshError?.()
             return
           } finally {
             subscribers.setAllowToRefetch(true)


### PR DESCRIPTION

Шаги по воспроизведению:
- accessToken и refreshToken протухли
- выполняем какой-нибудь запрос, получаем 401 ("AccessTokenInvalid")
- интерсептор перехватывает ошибку, пробует сделать /refresh, получает 401 ("RefreshTokenInvalid"), выполняется logout
- Не перезагружая приложение заново логинимся и ждём, пока протухнет accessToken
- Когда accessToken протух, пытаемся выполнить какой-нибудь запрос, получаем 401 ("AccessTokenInvalid"), но интерсептор не вызывает /refresh.

Всё дело в флаге isAllowToRefetch (getAllowToRefetch).
При запуске процесса обновления токенов его устанавливаем в false, чтобы другие упавшие с 401 ошибкой запросы не инициировали повторный refresh, после успеха обновления мы возвращаем isAllowToRefetch в true. Но вот если запрос /refresh упал с какой-либо ошибкой, isAllowToRefetch в true сейчас не возвращается, поэтому после логаута, повторного логина, когда снова надо рефрешить токены они не рефрешатся, т.к. isAllowToRefetch по прежнему false.

Решение: обернуть обновление токенов в try/catch, при ошибке как и при успехе сбрасывать isAllowToRefetch в true.